### PR TITLE
Various fixes for wmibeat

### DIFF
--- a/beater/wmibeat.go
+++ b/beater/wmibeat.go
@@ -5,7 +5,6 @@ import (
 	"time"
 	"strings"
 	"bytes"
-	"strconv"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
@@ -111,102 +110,76 @@ func (bt *Wmibeat) RunOnce(b *beat.Beat) error {
 
 	service := serviceObj.ToIDispatch()
 
-	var allValues common.MapStr
 	for _, class := range bt.beatConfig.Wmibeat.Classes {
-		if len(class.Fields) > 0 {
-			var query bytes.Buffer
-			wmiFields := class.Fields
-			query.WriteString("SELECT ")
-			query.WriteString(strings.Join(wmiFields, ","))
-			query.WriteString(" FROM ")
-			query.WriteString(class.Class)
-			if class.WhereClause != "" {
-				query.WriteString(" WHERE ")
-				query.WriteString(class.WhereClause)
-			}
-			logp.Info("Query: " + query.String())
-
-			resultObj, err := oleutil.CallMethod(service, "ExecQuery", query.String(), "WQL")
-			if err != nil {
-				logp.Err("Unable to execute query: %v", err)
-				return err
-			}
-			defer resultObj.Clear()
-
-			result := resultObj.ToIDispatch()
-			countObj, err := oleutil.GetProperty(result, "Count")
-			if err != nil {
-				logp.Err("Unable to get result count: %v", err)
-				return err
-			}
-			defer countObj.Clear()
-
-			count := int(countObj.Val)
-
-			var classValues interface {} = nil
-			
-			if (class.ObjectTitle != "") {
-				classValues = common.MapStr{}
-			} else {
-				classValues = []common.MapStr{}
-			}
-			for i :=0; i < count; i++ {
-				rowObj, err := oleutil.CallMethod(result, "ItemIndex", i)
-				if err != nil {
-					logp.Err("Unable to get result item by index: %v", err)
-					return err
-				}
-				defer rowObj.Clear()
-
-				row := rowObj.ToIDispatch()
-				var rowValues common.MapStr
-				var objectTitle = ""
-				for _, j := range wmiFields {
-					wmiObj, err := oleutil.GetProperty(row, j)
-					if err != nil {
-						logp.Err("Unable to get propery by name: %v", err)
-						return err
-					}
-					defer wmiObj.Clear()
-
-					var objValue = wmiObj.Value()
-					if (class.ObjectTitle == j) {
-						objectTitle = objValue.(string)
-					}
-					rowValues = common.MapStrUnion(rowValues, common.MapStr { j: objValue } )
-					
-				}
-				if (class.ObjectTitle != "") {
-					if (objectTitle != "") {
-						classValues =  common.MapStrUnion(classValues.(common.MapStr), common.MapStr { objectTitle: rowValues })
-					} else {
-						classValues =  common.MapStrUnion(classValues.(common.MapStr), common.MapStr { strconv.Itoa(i): rowValues })
-					}
-				} else {
-					classValues = append(classValues.([]common.MapStr), rowValues)
-				}
-				rowValues = nil
-			}
-			allValues = common.MapStrUnion(allValues, common.MapStr { class.Class: classValues })
-			classValues = nil
-			
-		} else {
+		if len(class.Fields) == 0 {
 			var errorString bytes.Buffer
 			errorString.WriteString("No fields defined for class ")
 			errorString.WriteString(class.Class)
 			errorString.WriteString(".  Skipping")
 			logp.Warn(errorString.String())
+			continue
+		}
+
+		var query bytes.Buffer
+		wmiFields := class.Fields
+		query.WriteString("SELECT ")
+		query.WriteString(strings.Join(wmiFields, ","))
+		query.WriteString(" FROM ")
+		query.WriteString(class.Class)
+		if class.WhereClause != "" {
+			query.WriteString(" WHERE ")
+			query.WriteString(class.WhereClause)
+		}
+		logp.Info("Query: " + query.String())
+
+		resultObj, err := oleutil.CallMethod(service, "ExecQuery", query.String(), "WQL")
+		if err != nil {
+			logp.Err("Unable to execute query: %v", err)
+			return err
+		}
+		defer resultObj.Clear()
+
+		result := resultObj.ToIDispatch()
+		countObj, err := oleutil.GetProperty(result, "Count")
+		if err != nil {
+			logp.Err("Unable to get result count: %v", err)
+			return err
+		}
+		defer countObj.Clear()
+
+		count := int(countObj.Val)
+
+		for i :=0; i < count; i++ {
+			rowObj, err := oleutil.CallMethod(result, "ItemIndex", i)
+			if err != nil {
+				logp.Err("Unable to get result item by index: %v", err)
+				return err
+			}
+			defer rowObj.Clear()
+
+			row := rowObj.ToIDispatch()
+
+			event := common.MapStr{
+				"@timestamp": common.Time(time.Now()),
+				"type":       b.Name,
+				"class":    class.Class,
+			}
+
+			for _, fieldName := range wmiFields {
+				wmiObj, err := oleutil.GetProperty(row, fieldName)
+				if err != nil {
+					logp.Err("Unable to get propery by name: %v", err)
+					return err
+				}
+				defer wmiObj.Clear()
+
+				var objValue = wmiObj.Value()
+				event[fieldName] = objValue
+			}
+
+			b.Events.PublishEvent(event)
 		}
 	}
-
-	event := common.MapStr{
-		"@timestamp": common.Time(time.Now()),
-		"type":       b.Name,
-		"wmi":    allValues,
-	}
-
-	b.Events.PublishEvent(event)
-	logp.Info("Event sent")
 
 	return err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,5 +16,4 @@ type ClassConfig struct {
 	Class       string    `config:"class"`
 	Fields      []string  `config:"fields"`
 	WhereClause string    `config:"whereclause"`
-	ObjectTitle string    `config:"objecttitlecolumn"`
 }


### PR DESCRIPTION
Hello, I've recently looked into the wmibeat implementation and found several issues in it. The commits in this pull request are to be considered separately.
1.  Fix wmibeat unexpected failures and resource leak
   There was a crucial resource leak because Golang's defer mechanism won't work unless surrounding function quits (originally the defers where made inside endless loop). I had to extract all the logic into a separate function (RunOnce) to make sure the resources are cleaned up.
   Additionally, it appears that sometimes Go runtime switches the processing threads, so from COM perspective it is required to call CoInitializeEx(0, 0) instead of CoInitialize(0) to ensure multithreading (the issue is easily reproducible with period=1s).
2.  Update wmibeat to save WMI result object as separate docs
   Originally the wmibeat was saving a single Elasticsearch documents with results, which made it always impossible to display in Kibana (e.g. when you query any class with multiple instances like Win32_PerfFormattedData_PerfProc_Process you won't be able to draw a chart with per-process memory usage - any aggregation will be impossible to do). That's why the output format is changed in favour of separate elasticsearch documents for each instance in the queried WMI classes. This change also allowed to remove lots of code including "ObjectTitleColumn" processing.
3.  Compile WMI queries only once during beat setup
   This is another performance improvement but rather small one - instead of compiling queries every time they are built only once in the Config step.
4.  Update wmibeat to latest libbeat API
   It was not possible to build wmibeat with latest Beats API because of their breaking changes.

Could you please perform the code review? - I'd really like to hear your comments.

Best regards,
Artsiom
